### PR TITLE
Implement functionality to add and convert roman numerals

### DIFF
--- a/src/RomanNumeralComponent.js
+++ b/src/RomanNumeralComponent.js
@@ -3,11 +3,36 @@ import React, {useState} from 'react';
 export default function RomanNumeralComponent () {
     const [calculatedAnswer, updateAnswer] = useState("Nulla");
     const [input, updateInput] = useState("");
-
+    const baseValues = {
+        M: 1000,
+        CM: 900,
+        D: 500,
+        CD: 400,
+        C: 100,
+        XC: 90,
+        L: 50,
+        XL: 40,
+        X: 10,
+        IX: 9,
+        V: 5,
+        IV: 4,
+        I: 1
+    };
 
     const addAndConvertToRomanNumerals = (ints) => {
-        /* Implement me! */
-        return ints;
+        let sumOfInts = ints.reduce((total, int) => (total + int), 0);
+        let romanNumeral = '';
+
+        if (sumOfInts > 1000) return alert('Sum should not be greater than 1000');
+
+        Object.keys(baseValues).forEach(key => {
+            while(sumOfInts >= baseValues[key]) {
+                romanNumeral += key;
+                sumOfInts -= baseValues[key];
+            }
+        })
+
+        return romanNumeral.length > 0 ? romanNumeral : 'Nulla';
     }
 
     const addNumbers = (inputString) => {


### PR DESCRIPTION
### What does this PR do?
- This PR implements the `add and convert to roman numerals` functionality

### How can this be tested?
- checkout to `roman-convert-implementation`
- run `npm install && npm start`
- in the input field, submit a list of numbers separated by commas [Eg: `1, 19, 45`]
- confirm that the displayed result is the equivalent of the sum of your submitted numbers in Roman numerals
- Input a number or sum of numbers greater than `1000` and confirm that an alert with the message, `Sum should not be greater than 1000` is rendered.

![2019-10-05-00-57-22](https://user-images.githubusercontent.com/43746609/66246432-e2f6ea80-e70b-11e9-9de3-3af2dc88671c.gif)
